### PR TITLE
Added API route to request a specific skill

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,13 +28,7 @@ data = {
     "skill": [
         Skill("Python",
               "1-2 Years",
-              "example-logo.png"),
-        Skill("C",
-              "3-4 Years",
-              "example-logo.png"),
-        Skill("Java",
-              "2-3 Years",
-              "example-logo.png"),
+              "example-logo.png")
     ]
 }
 

--- a/app.py
+++ b/app.py
@@ -28,7 +28,13 @@ data = {
     "skill": [
         Skill("Python",
               "1-2 Years",
-              "example-logo.png")
+              "example-logo.png"),
+        Skill("C",
+              "3-4 Years",
+              "example-logo.png"),
+        Skill("Java",
+              "2-3 Years",
+              "example-logo.png"),
     ]
 }
 
@@ -68,12 +74,18 @@ def education():
     return jsonify({})
 
 
-@app.route('/resume/skill', methods=['GET', 'POST'])
-def skill():
+@app.route('/resume/skill/', methods=['GET', 'POST'])
+@app.route('/resume/skill/<index>', methods=['GET', 'POST'])
+def skill(index=None):
     '''
     Handles Skill requests
     '''
     if request.method == 'GET':
+        if index is not None:
+            try:
+                return jsonify(data['skill'][int(index)])
+            except IndexError:
+                return jsonify({'error': f'No skill with index {index} was found'})
         return jsonify(data["skill"])
 
     if request.method == 'POST':

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -67,8 +67,8 @@ def test_skill():
         "logo": "example-logo.png"
     }
 
-    item_id = app.test_client().post('/resume/skill',
+    item_id = app.test_client().post('/resume/skill/',
                                      json=example_skill).json['id']
 
-    response = app.test_client().get('/resume/skill')
+    response = app.test_client().get('/resume/skill/')
     assert response.json[item_id] == example_skill


### PR DESCRIPTION
Updated the /resume/skill API route to be able to take an index as a parameter and return the skill of that index. If no index is provided, all skills are returned. In addition, I added a few extra skills to the test data as this allowed me to test my added feature more completely. 